### PR TITLE
Fix warning when accessing roles property for non-existing users

### DIFF
--- a/admin/classes/class-commenting-block-rest-routes.php
+++ b/admin/classes/class-commenting-block-rest-routes.php
@@ -175,7 +175,7 @@ class Commenting_Block_Rest_Routes extends Commenting_block_Functions {
 					'lastUser'          => $editedLastUser,
 					'defaultAuthor'     => $defaultAuthor,
 					'defaultAuthorLink' => $defaultAuthorLink,
-					'defaultUserRole'   => $Defaultusers->roles[0],
+					'defaultUserRole'   => $Defaultusers->roles[0] ?? '',
 					'lastEditedTime'    => $lasteditedtime,
 					'lastUsersUrl'      => $lasteditedUsersUrl,
 					'type'              => 'el',


### PR DESCRIPTION
Issue: https://github.com/multidots/multicollab/issues/60.

Adding a null coalescing operator to avoid the `Attempt to read property "roles" on bool` warnings if the `$Defaultusers` is `false`.

This will also cover other scenarios, like a missing or not array `roles` property, as well as the user not having any roles set.